### PR TITLE
Implement chat history in session

### DIFF
--- a/help-desk-agent-flask-app/static/main.js
+++ b/help-desk-agent-flask-app/static/main.js
@@ -1,7 +1,28 @@
+function loadHistory() {
+    const historyDiv = document.getElementById("chat-history");
+    historyDiv.innerHTML = "";
+    const history = JSON.parse(sessionStorage.getItem("chatHistory") || "[]");
+    history.forEach(item => {
+        const p = document.createElement("p");
+        const sender = item.sender === "user" ? "You" : "Assistant";
+        p.textContent = `${sender}: ${item.text}`;
+        historyDiv.appendChild(p);
+    });
+    historyDiv.scrollTop = historyDiv.scrollHeight;
+}
+
+function addToHistory(sender, text) {
+    const history = JSON.parse(sessionStorage.getItem("chatHistory") || "[]");
+    history.push({ sender: sender, text: text });
+    sessionStorage.setItem("chatHistory", JSON.stringify(history));
+    loadHistory();
+}
+
 async function sendMessage() {
     const message = document.getElementById("user-input").value;
     const responseDiv = document.getElementById("response");
 
+    addToHistory("user", message);
     responseDiv.innerHTML = "<em>Thinking...</em>";
 
     const response = await fetch("/ask", {
@@ -13,6 +34,7 @@ async function sendMessage() {
     });
 
     const data = await response.json();
+    addToHistory("assistant", data.response);
     responseDiv.textContent = data.response;
     document.getElementById("user-input").value = "";
 }
@@ -20,6 +42,7 @@ async function sendMessage() {
 // Enable Enter to send, Shift+Enter to newline
 document.addEventListener("DOMContentLoaded", function () {
     const textarea = document.getElementById("user-input");
+    loadHistory();
 
     textarea.addEventListener("keydown", function (e) {
         if (e.key === "Enter" && !e.shiftKey) {

--- a/help-desk-agent-flask-app/templates/index.html
+++ b/help-desk-agent-flask-app/templates/index.html
@@ -26,6 +26,7 @@
 <div class="container mt-5">
     <h1 class="text-center mb-4">🤖 EHRM Help Desk Ticket Analysis Assistant</h1>
     <div class="chat-box mx-auto" style="max-width: 700px;">
+        <div id="chat-history" class="mb-3" style="max-height: 300px; overflow-y: auto;"></div>
         <form onsubmit="sendMessage(); return false;">
             <div class="mb-3">
                 <textarea id="user-input" class="form-control" rows="4" placeholder="Type your message here..."></textarea>


### PR DESCRIPTION
## Summary
- store user and assistant messages in browser sessionStorage
- show the chat history area in the UI

## Testing
- `python -m py_compile help-desk-agent-flask-app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687e9c11b9088332a74d7ff8e724e208