### PR TITLE
Remove redundant chat response box

### DIFF
--- a/help-desk-agent-flask-app/static/main.js
+++ b/help-desk-agent-flask-app/static/main.js
@@ -20,10 +20,8 @@ function addToHistory(sender, text) {
 
 async function sendMessage() {
     const message = document.getElementById("user-input").value;
-    const responseDiv = document.getElementById("response");
 
     addToHistory("user", message);
-    responseDiv.innerHTML = "<em>Thinking...</em>";
 
     const response = await fetch("/ask", {
         method: "POST",
@@ -35,7 +33,6 @@ async function sendMessage() {
 
     const data = await response.json();
     addToHistory("assistant", data.response);
-    responseDiv.textContent = data.response;
     document.getElementById("user-input").value = "";
 }
 

--- a/help-desk-agent-flask-app/templates/index.html
+++ b/help-desk-agent-flask-app/templates/index.html
@@ -14,12 +14,6 @@
             padding: 20px;
             box-shadow: 0 0 10px rgba(0,0,0,0.1);
         }
-        .response-box {
-            margin-top: 15px;
-            background-color: #e9ecef;
-            padding: 15px;
-            border-radius: 8px;
-        }
     </style>
 </head>
 <body>
@@ -35,7 +29,6 @@
                 <button type="submit" class="btn btn-primary">Send</button>
             </div>
         </form>
-        <div class="response-box mt-4" id="response">Awaiting your prompt...</div>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- remove unused response box from the HTML template
- stop writing to the removed response box in JavaScript

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8cad8fd483328db14cd0305efc56