### PR TITLE
Clear chat input immediately after message send

### DIFF
--- a/help-desk-agent-flask-app/static/main.js
+++ b/help-desk-agent-flask-app/static/main.js
@@ -19,9 +19,11 @@ function addToHistory(sender, text) {
 }
 
 async function sendMessage() {
-    const message = document.getElementById("user-input").value;
+    const inputBox = document.getElementById("user-input");
+    const message = inputBox.value;
 
     addToHistory("user", message);
+    inputBox.value = "";
 
     const response = await fetch("/ask", {
         method: "POST",
@@ -33,7 +35,6 @@ async function sendMessage() {
 
     const data = await response.json();
     addToHistory("assistant", data.response);
-    document.getElementById("user-input").value = "";
 }
 
 // Enable Enter to send, Shift+Enter to newline


### PR DESCRIPTION
## Summary
- Clear the chat input box as soon as a message is submitted so the conversation updates without delay.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f8be356a483329bcdd23e08af2bd3