### PR TITLE
feat: render chat output using GFM

### DIFF
--- a/help-desk-agent-flask-app/static/main.js
+++ b/help-desk-agent-flask-app/static/main.js
@@ -1,12 +1,21 @@
+marked.setOptions({
+    gfm: true,
+    breaks: true
+});
+
 function loadHistory() {
     const historyDiv = document.getElementById("chat-history");
     historyDiv.innerHTML = "";
     const history = JSON.parse(sessionStorage.getItem("chatHistory") || "[]");
     history.forEach(item => {
-        const p = document.createElement("p");
-        const sender = item.sender === "user" ? "You" : "Assistant";
-        p.textContent = `${sender}: ${item.text}`;
-        historyDiv.appendChild(p);
+        const container = document.createElement("div");
+        const senderLabel = document.createElement("strong");
+        senderLabel.textContent = `${item.sender === "user" ? "You" : "Assistant"}:`;
+        const message = document.createElement("div");
+        message.innerHTML = marked.parse(item.text);
+        container.appendChild(senderLabel);
+        container.appendChild(message);
+        historyDiv.appendChild(container);
     });
     historyDiv.scrollTop = historyDiv.scrollHeight;
 }

--- a/help-desk-agent-flask-app/templates/index.html
+++ b/help-desk-agent-flask-app/templates/index.html
@@ -48,6 +48,7 @@
     </div>
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use marked.js to render chat history with GitHub Flavored Markdown
- enable GFM parsing for all chat messages

## Testing
- `node --check help-desk-agent-flask-app/static/main.js`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

Closes #10

------
https://chatgpt.com/codex/tasks/task_e_6890c4b164bc8332af30a81d2c12b7d2