### PR TITLE
Add ticket detail view and open-link support

### DIFF
--- a/help-desk-agent-flask-app/agent.py
+++ b/help-desk-agent-flask-app/agent.py
@@ -14,10 +14,11 @@ def create_agent_with_memory():
     system_prompt = (
     "You are a helpful assistant for the Department of Veterans Affairs (VA) employees. "
     "Your job is to help answer VA employees with questions about issues related to the "
-    "electronic health record modernization (EHRM) enterprise rollout. Always use the ticket "
-    "citation tool to cite specific tickets that you used in your answer. Only use ticket information "
-    "gathered from tools to answer questions. If you do not have enough information, "
-    "let the user know that you need more details or to clarify the question."
+    "electronic health record modernization (EHRM) enterprise rollout. Whenever you use "
+    "ticket information (by description, issue summary, or content), you **must** call the "
+    "`ticket_citation_tool` with the relevant `ticket_id` to generate a hyperlink. "
+    "You **must not** refer to ticket info without hyperlinking. If you do not have enough "
+    "information, let the user know that you need more details or to clarify the question."
     )
     llm = ChatGoogleGenerativeAI(model="gemini-2.5-flash-lite", temperature=1.0)
     rag_tool = get_rag_tool()

--- a/help-desk-agent-flask-app/app.py
+++ b/help-desk-agent-flask-app/app.py
@@ -2,18 +2,41 @@
 from flask import Flask, render_template, request, jsonify
 from dotenv import load_dotenv
 from llm_handler import get_agent_response
+import sqlite3
+import os
 
 app = Flask(__name__)
+
 
 @app.route("/")
 def home():
     return render_template("index.html")
+
 
 @app.route("/ask", methods=["POST"])
 def ask():
     user_input = request.form.get("message")
     response = get_agent_response(user_input)
     return jsonify({"response": response})
+
+
+@app.route("/ticket/<ticket_id>")
+def ticket_detail(ticket_id: str):
+    """Display an individual help desk ticket."""
+    db_path = os.path.join(app.root_path, "sqlite_db", "help_desk_agent.sqlite3")
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT * FROM va_helpdesk_tickets_sample_realistic WHERE TicketID = ?",
+        (ticket_id,),
+    )
+    row = cur.fetchone()
+    conn.close()
+    if row is None:
+        return "Ticket not found", 404
+    return render_template("ticket.html", ticket=dict(row))
+
 
 if __name__ == "__main__":
     load_dotenv()

--- a/help-desk-agent-flask-app/app.py
+++ b/help-desk-agent-flask-app/app.py
@@ -23,7 +23,7 @@ def ask():
 @app.route("/ticket/<ticket_id>")
 def ticket_detail(ticket_id: str):
     """Display an individual help desk ticket."""
-    db_path = os.path.join(app.root_path, "sqlite_db", "help_desk_agent.sqlite3")
+    db_path = "../../datasets/help-desk-tickets/sqlite_db/help_desk_agent.sqlite3"
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     cur = conn.cursor()

--- a/help-desk-agent-flask-app/static/main.js
+++ b/help-desk-agent-flask-app/static/main.js
@@ -13,6 +13,7 @@ function loadHistory() {
         senderLabel.textContent = `${item.sender === "user" ? "You" : "Assistant"}:`;
         const message = document.createElement("div");
         message.innerHTML = marked.parse(item.text);
+        message.querySelectorAll('a').forEach(a => a.setAttribute('target', '_blank'));
         container.appendChild(senderLabel);
         container.appendChild(message);
         historyDiv.appendChild(container);

--- a/help-desk-agent-flask-app/templates/ticket.html
+++ b/help-desk-agent-flask-app/templates/ticket.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Ticket {{ ticket['TicketID'] }}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-4">
+    <h1>Ticket {{ ticket['TicketID'] }}</h1>
+    <table class="table table-bordered">
+        <tbody>
+        {% for key, value in ticket.items() %}
+            <tr>
+                <th>{{ key }}</th>
+                <td>{{ value }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/help-desk-agent-flask-app/ticket_citation_tool.py
+++ b/help-desk-agent-flask-app/ticket_citation_tool.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 class TicketCitationToolArgsSchema(BaseModel):
     ticket_id: str = Field(
         description=(
-            "The TicketID for the ticket you would like to cite."
+            "The TicketID for the ticket you would like to obtain a hyperlink to for citation purposes."
         )
     )
 
@@ -14,4 +14,4 @@ def ticket_citation_tool(ticket_id: str) -> str:
     """
     Tool to format a url reference to a ticket.
     """
-    return f'<a href="https://index/ticket_view?ticket-id={ticket_id}">[{ticket_id}]</a>'
+    return f'<a href="/ticket/{ticket_id}">[{ticket_id}]</a>'


### PR DESCRIPTION
## Summary
- create endpoint to fetch and display help desk ticket details by TicketID
- render ticket data in new ticket.html template
- ensure chat links open in new tab

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892240641848332b16ce3428ad9c9ff